### PR TITLE
fixing the min-int version of php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 5.5
   - 5.6
   - 7
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@
     <screenshot>https://raw.githubusercontent.com/janis91/nextnotes/master/screenshots/sc2.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/janis91/nextnotes/master/screenshots/sc3.png</screenshot>
     <dependencies>
-        <php min-version="5.5" max-version="7" min-int-size="64" />
+        <php min-version="5.5" max-version="7" min-int-size="32" />
         <database min-version="9.4">pgsql</database>
         <database>mysql</database>
         <database>sqlite</database>


### PR DESCRIPTION
fixing the min-int version of php

## Related Issue
#12 

## Motivation and Context
It gives more users the ability to use nextnotes.

## How Has This Been Tested?
travis.yml updated for more php versions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

