### PR TITLE
CSP changed - Bugfix 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.5
   - 5.6
   - 7
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@
     <screenshot>https://raw.githubusercontent.com/janis91/nextnotes/master/screenshots/sc2.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/janis91/nextnotes/master/screenshots/sc3.png</screenshot>
     <dependencies>
-        <php min-version="5.5" max-version="7" min-int-size="32" />
+        <php min-version="5.6" max-version="7" min-int-size="32" />
         <database min-version="9.4">pgsql</database>
         <database>mysql</database>
         <database>sqlite</database>

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -11,6 +11,7 @@
 
 namespace OCA\NextNotes\Controller;
 
+use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Controller;
@@ -39,7 +40,13 @@ class PageController extends Controller {
      * @return TemplateResponse
      */
     public function index() {
-        return new TemplateResponse('nextnotes', 'main');
+        $response = new TemplateResponse('nextnotes', 'main');
+		$policy = new ContentSecurityPolicy();
+		$policy->addAllowedChildSrcDomain('\'self\'');
+		$policy->addAllowedFontDomain('data:');
+		$policy->addAllowedImageDomain('*');
+		$response->setContentSecurityPolicy($policy);
+		return $response;
     }
 
 

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -34,6 +34,7 @@ class PageControllerTest extends TestCase {
 
 		$this->assertEquals('main', $result->getTemplateName());
 		$this->assertTrue($result instanceof TemplateResponse);
+		$this->assertNotNull($result->getContentSecurityPolicy());
 	}
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the CSP header to the template response in order to display images that are linked in markdown.
Currently like specified in #20 the images have to be globally available.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#19 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Images didn't show up after added in markdown.  CSP has been changed accordingly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to or you wrote. -->
<!--- see how your change affects other areas of the code, etc. -->
tested manually and with unit testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.